### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Set up a Trello connector"
-description: "C1 provides identity governance and just-in-time provisioning for Trello. Integrate your Trello instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+description: "C1 provides identity governance for Trello. Integrate your Trello instance with C1 for unified visibility and governance over user access."
 og:title: "Set up a Trello connector"
-og:description: "C1 provides identity governance and just-in-time provisioning for Trello. Integrate your Trello instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+og:description: "C1 provides identity governance for Trello. Integrate your Trello instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "Atlassian Trello"
 ---
 
@@ -73,7 +73,7 @@ Finally, we'll use the Trello API to look up the IDs of the Trello organizations
     </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Trello connector
 
@@ -129,7 +129,7 @@ Finally, we'll use the Trello API to look up the IDs of the Trello organizations
     </Step>
 </Steps>
 
-**That's it!** Your Trello connector is now pulling access data into C1.
+**Done.** Your Trello connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the Trello connector, hosted and run in your own environment.**
@@ -242,7 +242,7 @@ spec:
     </Step>
 </Steps>
 
-**That's it!** Your Trello connector is now pulling access data into C1.
+**Done.** Your Trello connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines