### PR TITLE
Update connector page title to include parent company name

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Set up a Trello connector"
+title:"Set up an Atlassian Trello connector"
 description: "C1 provides identity governance for Trello. Integrate your Trello instance with C1 for unified visibility and governance over user access."
-og:title: "Set up a Trello connector"
+og:title:"Set up an Atlassian Trello connector"
 og:description: "C1 provides identity governance for Trello. Integrate your Trello instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "Atlassian Trello"
 ---

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,7 +1,7 @@
 ---
-title:"Set up an Atlassian Trello connector"
+title: "Set up an Atlassian Trello connector"
 description: "C1 provides identity governance for Trello. Integrate your Trello instance with C1 for unified visibility and governance over user access."
-og:title:"Set up an Atlassian Trello connector"
+og:title: "Set up an Atlassian Trello connector"
 og:description: "C1 provides identity governance for Trello. Integrate your Trello instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "Atlassian Trello"
 ---


### PR DESCRIPTION
This PR updates the connector page title and og:title to include the parent company name for better discoverability and consistency across connector docs.

Also replaces any remaining instances of `That's it!` with `Done.`