### PR TITLE
fix: lock for write in GetMemberships cache-fill paths

### DIFF
--- a/pkg/connector/boards.go
+++ b/pkg/connector/boards.go
@@ -205,8 +205,8 @@ func evaluateMembership(membershipType, permission string) bool {
 }
 
 func (o *boardBuilder) GetMemberships(ctx context.Context, boardID string) error {
-	o.membershipsMutex.RLock()
-	defer o.membershipsMutex.RUnlock()
+	o.membershipsMutex.Lock()
+	defer o.membershipsMutex.Unlock()
 
 	if o.memberships == nil {
 		o.memberships = make(map[string][]client.User)

--- a/pkg/connector/organizations.go
+++ b/pkg/connector/organizations.go
@@ -121,8 +121,8 @@ func newOrganizationBuilder(c *client.TrelloClient) *organizationBuilder {
 }
 
 func (o *organizationBuilder) GetMemberships(ctx context.Context, organizationID string) error {
-	o.membershipsMutex.RLock()
-	defer o.membershipsMutex.RUnlock()
+	o.membershipsMutex.Lock()
+	defer o.membershipsMutex.Unlock()
 
 	if o.memberships == nil {
 		o.memberships = make(map[string][]client.User)

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -159,6 +159,7 @@ func TestTrelloClient_GetUserDetails(t *testing.T) {
 	// Verify the result.
 	if user == nil {
 		t.Fatal("Expected non-nil result")
+		return // unreachable; satisfies staticcheck SA5011 which can't model t.Fatal
 	}
 
 	expectedUser := client.User{


### PR DESCRIPTION
Both \`boardBuilder.GetMemberships\` and \`organizationBuilder.GetMemberships\` acquired \`RLock\` on \`membershipsMutex\`, then -- on the cache-miss path -- wrote to the shared \`o.memberships\` map (initialising the nil map and storing the per-id slice). \`RLock\` permits multiple readers AND multiple \`RLock\` holders, so the assignments raced against any concurrent \`GetMemberships\` call. The runtime would either silently corrupt the map header or panic with \`concurrent map read and write\` / \`concurrent map writes\` once the windows lined up under load.

Switched both \`RLock\`/\`RUnlock\` pairs to the write \`Lock\`/\`Unlock\`. The contention is bounded by per-id cache-miss frequency (one per board / organization for the lifetime of the builder), so the additional serialisation is negligible.

How found: occult-go-analysis baton pool scan (2026-05-20), detector \`map_write_under_rlock\`.