### PR TITLE
fix: mark api-key and api-token as isSecret in config_schema

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,11 +10,13 @@ var (
 	ApiKeyField = field.StringField(
 		"api-key",
 		field.WithDescription("The API key for your Trello account"),
+		field.WithIsSecret(true),
 		field.WithRequired(true),
 	)
 	ApiTokenField = field.StringField(
 		"api-token",
 		field.WithDescription("The API token for your Trello account"),
+		field.WithIsSecret(true),
 		field.WithRequired(true),
 	)
 	OrganizationsField = field.StringSliceField(


### PR DESCRIPTION
## Summary
Marks the credential field(s) **api-key, api-token** as `isSecret: true` so the value is treated as a secret — masked in the UI and logs and stored securely rather than in plaintext.

Found by the connector config secret-ness audit (phase 16).

`config_schema.json` is generated at build time from `pkg/config/config.go` and is not committed to this repo, so `field.WithIsSecret(true)` on both field definitions is the authoritative fix.

> BREAKING: adding `isSecret: true` to these fields changes how existing
> configurations are stored. Customers with existing connector configurations
> will need to re-enter credentials after this change is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)