### PR TITLE
CXH-1897: containerize connector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOOS = $(shell go env GOOS)
 GOARCH = $(shell go env GOARCH)
 BUILD_DIR = dist/${GOOS}_${GOARCH}
-GENERATED_CONF = pkg/config/conf.gen.go
+GENERATED_CONF := pkg/config/conf.gen.go
 
 ifeq ($(GOOS),windows)
 OUTPUT_PATH = ${BUILD_DIR}/baton-trello.exe
@@ -9,16 +9,22 @@ else
 OUTPUT_PATH = ${BUILD_DIR}/baton-trello
 endif
 
+# Set the build tag conditionally based on ENABLE_LAMBDA
+ifdef BATON_LAMBDA_SUPPORT
+	BUILD_TAGS=-tags baton_lambda_support
+else
+	BUILD_TAGS=
+endif
+
 .PHONY: build
 build: $(GENERATED_CONF)
-	go build -o ${OUTPUT_PATH} ./cmd/baton-trello
+	go build ${BUILD_TAGS} -o ${OUTPUT_PATH} ./cmd/baton-trello
 
 $(GENERATED_CONF): pkg/config/config.go go.mod
+	@echo "Generating $(GENERATED_CONF)..."
 	go generate ./pkg/config
 
-.PHONY: generate
-generate:
-	go generate ./pkg/config
+generate: $(GENERATED_CONF)
 
 .PHONY: update-deps
 update-deps:
@@ -26,8 +32,8 @@ update-deps:
 	go mod tidy -v
 	go mod vendor
 
-.PHONY: add-dep
-add-dep:
+.PHONY: add-deps
+add-deps:
 	go mod tidy -v
 	go mod vendor
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else
 OUTPUT_PATH = ${BUILD_DIR}/baton-trello
 endif
 
-# Set the build tag conditionally based on ENABLE_LAMBDA
+# Set the build tag conditionally based on BATON_LAMBDA_SUPPORT
 ifdef BATON_LAMBDA_SUPPORT
 	BUILD_TAGS=-tags baton_lambda_support
 else

--- a/cmd/baton-trello/main.go
+++ b/cmd/baton-trello/main.go
@@ -2,63 +2,19 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	cfg "github.com/conductorone/baton-trello/pkg/config"
-	connectorSchema "github.com/conductorone/baton-trello/pkg/connector"
+	"github.com/conductorone/baton-trello/pkg/connector"
 	"github.com/conductorone/baton-sdk/pkg/config"
-	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/connectorrunner"
-	"github.com/conductorone/baton-sdk/pkg/types"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 )
 
 var version = "dev"
 
 func main() {
 	ctx := context.Background()
-
-	_, cmd, err := config.DefineConfiguration(
-		ctx,
-		"baton-trello",
-		getConnector,
-		cfg.Config,
-		connectorrunner.WithDefaultCapabilitiesConnectorBuilder(&connectorSchema.Connector{}),
+	config.RunConnector(ctx, "baton-trello", version, cfg.Config,
+		connector.NewLambdaConnector,
+		connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2(&connector.Connector{}),
 	)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-
-	cmd.Version = version
-
-	err = cmd.Execute()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-}
-
-func getConnector(ctx context.Context, tc *cfg.Trello) (types.ConnectorServer, error) {
-	l := ctxzap.Extract(ctx)
-
-	if err := cfg.ValidateConfig(tc); err != nil {
-		return nil, err
-	}
-
-	connectorBuilder, err := connectorSchema.New(ctx, tc.ApiKey, tc.ApiToken, tc.Organizations, tc.BaseUrl)
-	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-
-	connector, err := connectorbuilder.NewConnector(ctx, connectorBuilder)
-	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-
-	return connector, nil
 }

--- a/config_schema.json
+++ b/config_schema.json
@@ -94,7 +94,9 @@
     },
     {
       "name": "api-key",
+      "displayName": "API Key",
       "description": "The API key for your Trello account",
+      "placeholder": "your-trello-api-key",
       "isRequired": true,
       "isSecret": true,
       "stringField": {
@@ -105,7 +107,9 @@
     },
     {
       "name": "api-token",
+      "displayName": "API Token",
       "description": "The API token for your Trello account",
+      "placeholder": "your-trello-api-token",
       "isRequired": true,
       "isSecret": true,
       "stringField": {
@@ -116,6 +120,7 @@
     },
     {
       "name": "organizations",
+      "displayName": "Organizations",
       "description": "Limit syncing to specific organizations by providing organization slugs.",
       "isRequired": true,
       "stringSliceField": {
@@ -124,5 +129,8 @@
         }
       }
     }
-  ]
+  ],
+  "displayName": "Trello",
+  "helpUrl": "/docs/baton/trello",
+  "iconUrl": "/static/app-icons/trello.svg"
 }

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -56,20 +56,19 @@ A user with access to the **Power-Up Admin Portal** in Trello must perform this 
     </Step>
 </Steps>
 
-### Look up Trello organization IDs
+### Look up Trello organization slugs
 
-Finally, we'll use the Trello API to look up the IDs of the Trello organizations you want to sync to C1.
+Finally, look up the short name (slug) of each Trello organization you want to sync to C1.
 
 <Steps>
     <Step>
-    Navigate to `https://api.trello.com/1/organizations/[organization-name]?key=[API-key]&token=[API-token]`, passing in the organization's name and the values of the API key and token you created for `[organization-name]`, `[API-key]`, and `[API-token]`.
-	To look up an organization name, navigate to the organization in Trello and copy the name from the URL.
+    In Trello, navigate to the organization's workspace and copy the short name from the URL. The short name is the last segment of the URL — for example, `my-org` in `https://trello.com/my-org`.
     </Step>
     <Step>
-    Carefully copy and save the ID of the organization.
+    Carefully copy and save the slug.
     </Step>
     <Step>
-    Repeat the steps as needed to look up the IDs of additional organizations.
+    Repeat the steps as needed to collect the slugs of additional organizations.
     </Step>
 </Steps>
 
@@ -119,7 +118,7 @@ Finally, we'll use the Trello API to look up the IDs of the Trello organizations
     Paste the API token into the **API token** field.
     </Step>
     <Step>
-    Paste the comma-separated list of IDs of the organization you want to sync into the **Organizations** field.
+    Paste the comma-separated list of organization slugs you want to sync into the **Organizations** field.
     </Step>
     <Step>
     Click **Save**.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,18 +9,23 @@ import (
 var (
 	ApiKeyField = field.StringField(
 		"api-key",
+		field.WithDisplayName("API Key"),
+		field.WithPlaceholder("your-trello-api-key"),
 		field.WithDescription("The API key for your Trello account"),
 		field.WithIsSecret(true),
 		field.WithRequired(true),
 	)
 	ApiTokenField = field.StringField(
 		"api-token",
+		field.WithDisplayName("API Token"),
+		field.WithPlaceholder("your-trello-api-token"),
 		field.WithDescription("The API token for your Trello account"),
 		field.WithIsSecret(true),
 		field.WithRequired(true),
 	)
 	OrganizationsField = field.StringSliceField(
 		"organizations",
+		field.WithDisplayName("Organizations"),
 		field.WithDescription("Limit syncing to specific organizations by providing organization slugs."),
 		field.WithRequired(true),
 	)
@@ -36,12 +41,17 @@ var (
 )
 
 // Config is the configuration schema for the connector.
-var Config = field.NewConfiguration([]field.SchemaField{
-	ApiKeyField,
-	ApiTokenField,
-	OrganizationsField,
-	BaseURLField,
-})
+var Config = field.NewConfiguration(
+	[]field.SchemaField{
+		ApiKeyField,
+		ApiTokenField,
+		OrganizationsField,
+		BaseURLField,
+	},
+	field.WithConnectorDisplayName("Trello"),
+	field.WithIconUrl("/static/app-icons/trello.svg"),
+	field.WithHelpUrl("/docs/baton/trello"),
+)
 
 // ValidateConfig is run after the configuration is loaded, and should return an
 // error if it isn't valid. Implementing this function is optional, it only

--- a/pkg/connector/boards.go
+++ b/pkg/connector/boards.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -25,29 +23,29 @@ func (o *boardBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 	return boardResourceType
 }
 
-func (o *boardBuilder) List(ctx context.Context, _ *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (o *boardBuilder) List(ctx context.Context, _ *v2.ResourceId, _ resource.SyncOpAttrs) ([]*v2.Resource, *resource.SyncOpResults, error) {
 	var resources []*v2.Resource
 
 	// Note: Trello API doesn't support pagination for boards by organization queries.
 	boards, annotation, err := o.client.ListBoards(ctx)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	for _, board := range boards {
 		boardCopy := board
 		parentResourceId, err := resource.NewResourceID(organizationResourceType, board.IdOrganization)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 		boardResource, err := parseIntoBoardResource(ctx, &boardCopy, parentResourceId)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 		resources = append(resources, boardResource)
 	}
 
-	return resources, "", annotation, nil
+	return resources, &resource.SyncOpResults{Annotations: annotation}, nil
 }
 
 func parseIntoBoardResource(_ context.Context, board *client.Board, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
@@ -83,13 +81,13 @@ func parseIntoBoardResource(_ context.Context, board *client.Board, parentResour
 	return ret, nil
 }
 
-func (o *boardBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (o *boardBuilder) Entitlements(ctx context.Context, res *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
 	var entitlements []*v2.Entitlement
 
 	// Note: Trello API only support getting boards by ID so it is not a bulk operation. Pagination is not needed.
-	board, _, err := o.client.GetBoardDetails(ctx, resource.Id.Resource)
+	board, _, err := o.client.GetBoardDetails(ctx, res.Id.Resource)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	// Self join
@@ -99,65 +97,65 @@ func (o *boardBuilder) Entitlements(ctx context.Context, resource *v2.Resource, 
 	}
 	assigmentOptions := []entitlement.EntitlementOption{
 		entitlement.WithGrantableTo(userResourceType),
-		entitlement.WithDescription(fmt.Sprintf("Is %s for board %s in Trello", selfJoin, resource.DisplayName)),
-		entitlement.WithDisplayName(fmt.Sprintf("%s Board %s", resource.DisplayName, selfJoin)),
+		entitlement.WithDescription(fmt.Sprintf("Is %s for board %s in Trello", selfJoin, res.DisplayName)),
+		entitlement.WithDisplayName(fmt.Sprintf("%s Board %s", res.DisplayName, selfJoin)),
 	}
-	entitlements = append(entitlements, entitlement.NewPermissionEntitlement(resource, selfJoin, assigmentOptions...))
+	entitlements = append(entitlements, entitlement.NewPermissionEntitlement(res, selfJoin, assigmentOptions...))
 
 	// Voting
 	voting := fmt.Sprintf("Voting %s", board.Preferences.Voting)
 	assigmentOptions = []entitlement.EntitlementOption{
 		entitlement.WithGrantableTo(userResourceType),
-		entitlement.WithDescription(fmt.Sprintf("%s for board %s in Trello", voting, resource.DisplayName)),
-		entitlement.WithDisplayName(fmt.Sprintf("%s Board %s", resource.DisplayName, voting)),
+		entitlement.WithDescription(fmt.Sprintf("%s for board %s in Trello", voting, res.DisplayName)),
+		entitlement.WithDisplayName(fmt.Sprintf("%s Board %s", res.DisplayName, voting)),
 	}
-	entitlements = append(entitlements, entitlement.NewPermissionEntitlement(resource, voting, assigmentOptions...))
+	entitlements = append(entitlements, entitlement.NewPermissionEntitlement(res, voting, assigmentOptions...))
 
 	// Comments
 	comments := fmt.Sprintf("Comments %s", board.Preferences.Comments)
 	assigmentOptions = []entitlement.EntitlementOption{
 		entitlement.WithGrantableTo(userResourceType),
-		entitlement.WithDescription(fmt.Sprintf("%s for board %s in Trello", comments, resource.DisplayName)),
-		entitlement.WithDisplayName(fmt.Sprintf("%s Board %s", resource.DisplayName, comments)),
+		entitlement.WithDescription(fmt.Sprintf("%s for board %s in Trello", comments, res.DisplayName)),
+		entitlement.WithDisplayName(fmt.Sprintf("%s Board %s", res.DisplayName, comments)),
 	}
-	entitlements = append(entitlements, entitlement.NewPermissionEntitlement(resource, comments, assigmentOptions...))
+	entitlements = append(entitlements, entitlement.NewPermissionEntitlement(res, comments, assigmentOptions...))
 
 	// Invitations
 	invitations := fmt.Sprintf("Invitations %s", board.Preferences.Invitations)
 	assigmentOptions = []entitlement.EntitlementOption{
 		entitlement.WithGrantableTo(userResourceType),
-		entitlement.WithDescription(fmt.Sprintf("%s for board %s in Trello", invitations, resource.DisplayName)),
-		entitlement.WithDisplayName(fmt.Sprintf("%s Board %s", resource.DisplayName, invitations)),
+		entitlement.WithDescription(fmt.Sprintf("%s for board %s in Trello", invitations, res.DisplayName)),
+		entitlement.WithDisplayName(fmt.Sprintf("%s Board %s", res.DisplayName, invitations)),
 	}
-	entitlements = append(entitlements, entitlement.NewPermissionEntitlement(resource, invitations, assigmentOptions...))
+	entitlements = append(entitlements, entitlement.NewPermissionEntitlement(res, invitations, assigmentOptions...))
 
-	return entitlements, "", nil, nil
+	return entitlements, nil, nil
 }
 
-func (o *boardBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (o *boardBuilder) Grants(ctx context.Context, res *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
 	var grants []*v2.Grant
 
-	var boardID = resource.Id.Resource
+	var boardID = res.Id.Resource
 
 	// Note: Trello API only support getting boards by ID so it is not a bulk operation. Pagination is not needed.
 	board, _, err := o.client.GetBoardDetails(ctx, boardID)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 	err = o.GetMemberships(ctx, boardID)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	for _, membership := range o.memberships[boardID] {
-		userResource, _ := parseIntoUserResource(ctx, &membership, resource.Id)
+		userResource, _ := parseIntoUserResource(ctx, &membership, res.Id)
 		membershipType := membership.MemberType
 
 		// Self join
 		if board.Preferences.SelfJoin {
 			selfJoin := "self join enabled"
-			membershipGrant := grant.NewGrant(resource, selfJoin, userResource, grant.WithAnnotation(&v2.V1Identifier{
-				Id: fmt.Sprintf("board-grant:%s:%s:%s", resource.Id.Resource, membership.MemberID, selfJoin),
+			membershipGrant := grant.NewGrant(res, selfJoin, userResource, grant.WithAnnotation(&v2.V1Identifier{
+				Id: fmt.Sprintf("board-grant:%s:%s:%s", res.Id.Resource, membership.MemberID, selfJoin),
 			}))
 			grants = append(grants, membershipGrant)
 		}
@@ -165,8 +163,8 @@ func (o *boardBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 		// Voting
 		if evaluateMembership(membershipType, board.Preferences.Voting) {
 			voting := fmt.Sprintf("Voting %s", board.Preferences.Voting)
-			membershipGrant := grant.NewGrant(resource, voting, userResource, grant.WithAnnotation(&v2.V1Identifier{
-				Id: fmt.Sprintf("board-grant:%s:%s:%s", resource.Id.Resource, membership.MemberID, voting),
+			membershipGrant := grant.NewGrant(res, voting, userResource, grant.WithAnnotation(&v2.V1Identifier{
+				Id: fmt.Sprintf("board-grant:%s:%s:%s", res.Id.Resource, membership.MemberID, voting),
 			}))
 			grants = append(grants, membershipGrant)
 		}
@@ -174,8 +172,8 @@ func (o *boardBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 		// Comments
 		if evaluateMembership(membershipType, board.Preferences.Comments) {
 			comments := fmt.Sprintf("Comments %s", board.Preferences.Comments)
-			membershipGrant := grant.NewGrant(resource, comments, userResource, grant.WithAnnotation(&v2.V1Identifier{
-				Id: fmt.Sprintf("board-grant:%s:%s:%s", resource.Id.Resource, membership.MemberID, comments),
+			membershipGrant := grant.NewGrant(res, comments, userResource, grant.WithAnnotation(&v2.V1Identifier{
+				Id: fmt.Sprintf("board-grant:%s:%s:%s", res.Id.Resource, membership.MemberID, comments),
 			}))
 			grants = append(grants, membershipGrant)
 		}
@@ -183,14 +181,14 @@ func (o *boardBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 		// Invitations
 		if evaluateMembership(membershipType, board.Preferences.Invitations) {
 			invitations := fmt.Sprintf("Invitations %s", board.Preferences.Invitations)
-			membershipGrant := grant.NewGrant(resource, invitations, userResource, grant.WithAnnotation(&v2.V1Identifier{
-				Id: fmt.Sprintf("board-grant:%s:%s:%s", resource.Id.Resource, membership.MemberID, invitations),
+			membershipGrant := grant.NewGrant(res, invitations, userResource, grant.WithAnnotation(&v2.V1Identifier{
+				Id: fmt.Sprintf("board-grant:%s:%s:%s", res.Id.Resource, membership.MemberID, invitations),
 			}))
 			grants = append(grants, membershipGrant)
 		}
 	}
 
-	return grants, "", nil, nil
+	return grants, nil, nil
 }
 
 func newBoardBuilder(c *client.TrelloClient) *boardBuilder {

--- a/pkg/connector/boards.go
+++ b/pkg/connector/boards.go
@@ -3,7 +3,6 @@ package connector
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
@@ -13,10 +12,8 @@ import (
 )
 
 type boardBuilder struct {
-	resourceType     *v2.ResourceType
-	client           *client.TrelloClient
-	memberships      map[string][]client.User
-	membershipsMutex sync.RWMutex
+	resourceType *v2.ResourceType
+	client       *client.TrelloClient
 }
 
 func (o *boardBuilder) ResourceType(_ context.Context) *v2.ResourceType {
@@ -142,12 +139,12 @@ func (o *boardBuilder) Grants(ctx context.Context, res *v2.Resource, _ resource.
 	if err != nil {
 		return nil, nil, err
 	}
-	err = o.GetMemberships(ctx, boardID)
+	memberships, err := o.client.ListMembershipsByBoard(ctx, boardID)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	for _, membership := range o.memberships[boardID] {
+	for _, membership := range memberships {
 		userResource, _ := parseIntoUserResource(ctx, &membership, res.Id)
 		membershipType := membership.MemberType
 
@@ -200,27 +197,4 @@ func newBoardBuilder(c *client.TrelloClient) *boardBuilder {
 
 func evaluateMembership(membershipType, permission string) bool {
 	return (membershipType == "admin" && permission == "admins") || permission == "members"
-}
-
-func (o *boardBuilder) GetMemberships(ctx context.Context, boardID string) error {
-	o.membershipsMutex.Lock()
-	defer o.membershipsMutex.Unlock()
-
-	if o.memberships == nil {
-		o.memberships = make(map[string][]client.User)
-	}
-
-	if o.memberships[boardID] != nil || len(o.memberships[boardID]) > 0 {
-		return nil
-	}
-
-	memberships, err := o.client.ListMembershipsByBoard(ctx, boardID)
-
-	if err != nil {
-		return err
-	}
-
-	o.memberships[boardID] = memberships
-
-	return nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -2,12 +2,13 @@ package connector
 
 import (
 	"context"
-
 	"io"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
+	cfg "github.com/conductorone/baton-trello/pkg/config"
 	"github.com/conductorone/baton-trello/pkg/client"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -17,9 +18,9 @@ type Connector struct {
 	client *client.TrelloClient
 }
 
-// ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
-func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
-	return []connectorbuilder.ResourceSyncer{
+// ResourceSyncers returns a ResourceSyncerV2 for each resource type that should be synced from the upstream service.
+func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
+	return []connectorbuilder.ResourceSyncerV2{
 		newUserBuilder(d.client),
 		newOrganizationBuilder(d.client),
 		newBoardBuilder(d.client),
@@ -59,4 +60,13 @@ func New(ctx context.Context, apiKey string, apiToken string, orgs []string, bas
 	return &Connector{
 		client: trelloClient,
 	}, nil
+}
+
+// NewLambdaConnector returns a new ConnectorBuilderV2 suitable for use with RunConnector.
+func NewLambdaConnector(ctx context.Context, ac *cfg.Trello, _ *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
+	c, err := New(ctx, ac.ApiKey, ac.ApiToken, ac.Organizations, ac.BaseUrl)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c, nil, nil
 }

--- a/pkg/connector/organizations.go
+++ b/pkg/connector/organizations.go
@@ -3,7 +3,6 @@ package connector
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
@@ -13,10 +12,8 @@ import (
 )
 
 type organizationBuilder struct {
-	resourceType     *v2.ResourceType
-	client           *client.TrelloClient
-	memberships      map[string][]client.User
-	membershipsMutex sync.RWMutex
+	resourceType *v2.ResourceType
+	client       *client.TrelloClient
 }
 
 var memberTypes = []string{"admin", "normal", "observer"}
@@ -93,14 +90,12 @@ func (o *organizationBuilder) Grants(ctx context.Context, res *v2.Resource, _ re
 
 	var organizationID = res.Id.Resource
 
-	// Note: Trello API doesn't support pagination for member queries.
-	err := o.GetMemberships(ctx, organizationID)
-
+	memberships, err := o.client.ListMembershipsByOrg(ctx, organizationID)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	for _, membership := range o.memberships[organizationID] {
+	for _, membership := range memberships {
 		userResource, _ := parseIntoUserResource(ctx, &membership, res.Id)
 		membershipGrant := grant.NewGrant(res, membership.MemberType, userResource, grant.WithAnnotation(&v2.V1Identifier{
 			Id: fmt.Sprintf("org-grant:%s:%s:%s", res.Id.Resource, membership.MemberID, membership.MemberType),
@@ -116,27 +111,4 @@ func newOrganizationBuilder(c *client.TrelloClient) *organizationBuilder {
 		resourceType: organizationResourceType,
 		client:       c,
 	}
-}
-
-func (o *organizationBuilder) GetMemberships(ctx context.Context, organizationID string) error {
-	o.membershipsMutex.Lock()
-	defer o.membershipsMutex.Unlock()
-
-	if o.memberships == nil {
-		o.memberships = make(map[string][]client.User)
-	}
-
-	if o.memberships[organizationID] != nil || len(o.memberships[organizationID]) > 0 {
-		return nil
-	}
-
-	memberships, err := o.client.ListMembershipsByOrg(ctx, organizationID)
-
-	if err != nil {
-		return err
-	}
-
-	o.memberships[organizationID] = memberships
-
-	return nil
 }

--- a/pkg/connector/organizations.go
+++ b/pkg/connector/organizations.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -27,26 +25,26 @@ func (o *organizationBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 	return organizationResourceType
 }
 
-func (o *organizationBuilder) List(ctx context.Context, _ *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (o *organizationBuilder) List(ctx context.Context, _ *v2.ResourceId, _ resource.SyncOpAttrs) ([]*v2.Resource, *resource.SyncOpResults, error) {
 	var resources []*v2.Resource
 
 	// Note: Trello API only support getting organizations by ID so it is not a bulk operation. Pagination is not needed.
 	organizations, annotation, err := o.client.ListOrganizations(ctx)
 
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	for _, organization := range organizations {
 		orgCopy := organization
 		orgResource, err := parseIntoOrganizationResource(ctx, &orgCopy, nil)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 		resources = append(resources, orgResource)
 	}
 
-	return resources, "", annotation, nil
+	return resources, &resource.SyncOpResults{Annotations: annotation}, nil
 }
 
 func parseIntoOrganizationResource(_ context.Context, organization *client.Organization, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
@@ -75,42 +73,42 @@ func parseIntoOrganizationResource(_ context.Context, organization *client.Organ
 	return ret, nil
 }
 
-func (o *organizationBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (o *organizationBuilder) Entitlements(_ context.Context, res *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
 	var entitlements []*v2.Entitlement
 	for _, memberType := range memberTypes {
 		assigmentOptions := []entitlement.EntitlementOption{
 			entitlement.WithGrantableTo(userResourceType),
-			entitlement.WithDescription(fmt.Sprintf("Member type %s for organization %s in Trello", memberType, resource.DisplayName)),
-			entitlement.WithDisplayName(fmt.Sprintf("%s Organization %s", resource.DisplayName, memberType)),
+			entitlement.WithDescription(fmt.Sprintf("Member type %s for organization %s in Trello", memberType, res.DisplayName)),
+			entitlement.WithDisplayName(fmt.Sprintf("%s Organization %s", res.DisplayName, memberType)),
 		}
 
-		entitlements = append(entitlements, entitlement.NewPermissionEntitlement(resource, memberType, assigmentOptions...))
+		entitlements = append(entitlements, entitlement.NewPermissionEntitlement(res, memberType, assigmentOptions...))
 	}
 
-	return entitlements, "", nil, nil
+	return entitlements, nil, nil
 }
 
-func (o *organizationBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (o *organizationBuilder) Grants(ctx context.Context, res *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
 	var grants []*v2.Grant
 
-	var organizationID = resource.Id.Resource
+	var organizationID = res.Id.Resource
 
 	// Note: Trello API doesn't support pagination for member queries.
 	err := o.GetMemberships(ctx, organizationID)
 
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	for _, membership := range o.memberships[organizationID] {
-		userResource, _ := parseIntoUserResource(ctx, &membership, resource.Id)
-		membershipGrant := grant.NewGrant(resource, membership.MemberType, userResource, grant.WithAnnotation(&v2.V1Identifier{
-			Id: fmt.Sprintf("org-grant:%s:%s:%s", resource.Id.Resource, membership.MemberID, membership.MemberType),
+		userResource, _ := parseIntoUserResource(ctx, &membership, res.Id)
+		membershipGrant := grant.NewGrant(res, membership.MemberType, userResource, grant.WithAnnotation(&v2.V1Identifier{
+			Id: fmt.Sprintf("org-grant:%s:%s:%s", res.Id.Resource, membership.MemberID, membership.MemberType),
 		}))
 		grants = append(grants, membershipGrant)
 	}
 
-	return grants, "", nil, nil
+	return grants, nil, nil
 }
 
 func newOrganizationBuilder(c *client.TrelloClient) *organizationBuilder {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -6,8 +6,6 @@ import (
 	"github.com/conductorone/baton-trello/pkg/client"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
@@ -22,25 +20,25 @@ func (o *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 
 // List returns all the users from the database as resource objects.
 // Users include a UserTrait because they are the 'shape' of a standard user.
-func (o *userBuilder) List(ctx context.Context, _ *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (o *userBuilder) List(ctx context.Context, _ *v2.ResourceId, _ resource.SyncOpAttrs) ([]*v2.Resource, *resource.SyncOpResults, error) {
 	var resources []*v2.Resource
 
 	// Note: Trello API doesn't support pagination for member queries.
 	users, annotation, err := o.client.ListUsers(ctx)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	for _, user := range users {
 		userCopy := user
 		userResource, err := parseIntoUserResource(ctx, &userCopy, nil)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 		resources = append(resources, userResource)
 	}
 
-	return resources, "", annotation, nil
+	return resources, &resource.SyncOpResults{Annotations: annotation}, nil
 }
 
 func parseIntoUserResource(_ context.Context, user *client.User, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
@@ -76,13 +74,13 @@ func parseIntoUserResource(_ context.Context, user *client.User, parentResourceI
 }
 
 // Entitlements always returns an empty slice for users.
-func (o *userBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (o *userBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 // Grants always returns an empty slice for users since they don't have any entitlements.
-func (o *userBuilder) Grants(_ context.Context, _ *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (o *userBuilder) Grants(_ context.Context, _ *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func newUserBuilder(c *client.TrelloClient) *userBuilder {


### PR DESCRIPTION
Containerizes baton-trello per the containerization guide.
Changes: ConnectorBuilderV2/ResourceSyncerV2 migration, config.go metadata, gen/gen.go, Makefile BATON_LAMBDA_SUPPORT, main.go RunConnector, CI cleanup.
Linear: CXH-1897