### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/boards.go
+++ b/pkg/connector/boards.go
@@ -58,9 +58,7 @@ func parseIntoBoardResource(_ context.Context, board *client.Board, parentResour
 		"self_join":        board.Preferences.SelfJoin,
 	}
 
-	groupTraits := []resource.GroupTraitOption{
-		resource.WithGroupProfile(profile),
-	}
+	groupTraits := []resource.GroupTraitOption{}
 
 	displayName := board.Name
 
@@ -69,6 +67,7 @@ func parseIntoBoardResource(_ context.Context, board *client.Board, parentResour
 		boardResourceType,
 		board.ID,
 		groupTraits,
+		resource.WithResourceProfile(profile),
 		resource.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {

--- a/pkg/connector/organizations.go
+++ b/pkg/connector/organizations.go
@@ -50,9 +50,7 @@ func parseIntoOrganizationResource(_ context.Context, organization *client.Organ
 		"display_name":    organization.DisplayName,
 	}
 
-	groupTraits := []resource.GroupTraitOption{
-		resource.WithGroupProfile(profile),
-	}
+	groupTraits := []resource.GroupTraitOption{}
 
 	displayName := organization.DisplayName
 
@@ -61,6 +59,7 @@ func parseIntoOrganizationResource(_ context.Context, organization *client.Organ
 		organizationResourceType,
 		organization.ID,
 		groupTraits,
+		resource.WithResourceProfile(profile),
 		resource.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -52,8 +52,6 @@ func parseIntoUserResource(_ context.Context, user *client.User, parentResourceI
 	}
 
 	userTraits := []resource.UserTraitOption{
-		resource.WithUserProfile(profile),
-		resource.WithStatus(userStatus),
 		resource.WithUserLogin(user.Username),
 	}
 
@@ -64,6 +62,8 @@ func parseIntoUserResource(_ context.Context, user *client.User, parentResourceI
 		userResourceType,
 		user.ID,
 		userTraits,
+		resource.WithResourceProfile(profile),
+		resource.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 		resource.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
